### PR TITLE
OBL-22 chore: dockerfile build 시, poetry.lock 파일 사용

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN pip install poetry
 RUN pip install  peewee>=3.17.6
 RUN pip install  asyncmy>=0.2.10
 
-COPY pyproject.toml /app/
+COPY pyproject.toml poetry.lock /app/
 
 RUN poetry config virtualenvs.create false && poetry install --no-interaction --no-ansi --no-root
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -7324,4 +7324,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "7da3e373b34fb9e67372c8fbcb86021cc3a6ac2ce76a631e560a553965494728"
+content-hash = "2b992f5756ba1af1bd224044d21a0fd847cd88525c3d017d48ccfb07bbdad763"


### PR DESCRIPTION
## 🔗 관련 이슈
- OLB-22

## 🛠 변경 사항
- poetry.lock 사용 => docker build 시 과도한 cpu 사용과 시간 걸림